### PR TITLE
Remove pandomain AWS keys from CFN

### DIFF
--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -1,10 +1,21 @@
 package config
 
 import _root_.aws.AwsInstanceTags
+import com.amazonaws.auth.BasicAWSCredentials
 import play.api.Play.current
 import play.api._
 
 object RestorerConfig extends AwsInstanceTags {
+
+  case class AWSCredentials(accessKey:String)(val secretKey:String) {
+    lazy val awsApiCreds = new BasicAWSCredentials(accessKey, secretKey)
+  }
+  object AWSCredentials {
+    def apply(accessKey: Option[String], secretKey: Option[String]): Option[AWSCredentials] = for {
+      ak <- accessKey
+      sk <- secretKey
+    } yield AWSCredentials(ak)(sk)
+  }
 
   lazy val stage: String = readTag("Stage") match {
     case Some(value) => value
@@ -29,6 +40,9 @@ object RestorerConfig extends AwsInstanceTags {
 
   val accessKey: Option[String] = config.getString("AWS_ACCESS_KEY")
   val secretKey: Option[String] = config.getString("AWS_SECRET_KEY")
+  val creds = AWSCredentials(accessKey, secretKey)
+
   val pandomainKey: Option[String] = config.getString("pandomain.aws.key")
   val pandomainSecret: Option[String] = config.getString("pandomain.aws.secret")
+  val pandomainCreds = AWSCredentials(pandomainKey, pandomainSecret)
 }

--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -7,6 +7,8 @@ import play.api._
 
 object RestorerConfig extends AwsInstanceTags {
 
+  // we use the two sets of parameters here so that the secretKey doesn't
+  // end up in the case class's toString and other methods
   case class AWSCredentials(accessKey:String)(val secretKey:String) {
     lazy val awsApiCreds = new BasicAWSCredentials(accessKey, secretKey)
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -23,11 +23,7 @@ trait PanDomainAuthActions extends AuthActions {
   override def authCallbackUrl: String = RestorerConfig.hostName + "/oauthCallback"
   override lazy val domain: String = RestorerConfig.domain
 
-
-  override lazy val awsCredentials =
-    for (key <- RestorerConfig.pandomainKey;
-      secret <- RestorerConfig.pandomainSecret)
-      yield { new BasicAWSCredentials(key, secret) }
+  override lazy val awsCredentials = RestorerConfig.pandomainCreds.map(_.awsApiCreds)
 }
 
 
@@ -62,27 +58,6 @@ object Application extends Controller with PanDomainAuthActions {
         CORSable.CORS_ALLOW_METHODS -> "GET, DELETE, PUT",
         CORSable.CORS_ALLOW_HEADERS -> requestedHeaders)
     }
-  }
-
-  def info = AuthAction {
-    val accessKeys = Seq(RestorerConfig.accessKey ++ RestorerConfig.secretKey).flatten
-    val creds: String = {
-        if (accessKeys.length >= 2) {
-          "Config keys"
-        } else {
-          "Default Credentials"
-        }
-    }
-    val info = Seq(
-      "Hostname: " + RestorerConfig.hostName,
-      "Composer Domain: " + RestorerConfig.composerDomain,
-      "Templates Bucket: " + RestorerConfig.templatesBucket,
-      "Snapshots draft bucket: " + RestorerConfig.draftBucket,
-      "Snapshots live bucket: " + RestorerConfig.liveBucket,
-      "Credentials: " + creds
-    ).mkString("\n")
-
-    Ok(info)
   }
 
 }

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import controllers.Application._
 import play.api.mvc._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -9,5 +10,20 @@ object Management extends Controller {
 
   def healthCheck = Action {
     Ok("Ok")
+  }
+
+  def info = Action {
+    val info =
+      s"""
+      |Hostname: ${RestorerConfig.hostName}
+      |Composer Domain: ${RestorerConfig.composerDomain}
+      |Templates Bucket: ${RestorerConfig.templatesBucket}
+      |Snapshots draft bucket: ${RestorerConfig.draftBucket}
+      |Snapshots live bucket: ${RestorerConfig.liveBucket}
+      |Credentials: ${RestorerConfig.creds}
+      |Pandomain Credentials: ${RestorerConfig.pandomainCreds}
+      """.stripMargin
+
+    Ok(info)
   }
 }

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -6,13 +6,13 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import config.RestorerConfig
 
-object Management extends Controller {
+object Management extends Controller with PanDomainAuthActions {
 
   def healthCheck = Action {
     Ok("Ok")
   }
 
-  def info = Action {
+  def info = AuthAction {
     val info =
       s"""
       |Hostname: ${RestorerConfig.hostName}

--- a/app/s3/S3.scala
+++ b/app/s3/S3.scala
@@ -15,14 +15,13 @@ class S3 {
 
   lazy val draftBucket: String = config.draftBucket
   lazy val liveBucket: String = config.liveBucket
-  val accessKeys = Seq(config.accessKey ++ config.secretKey).flatten
 
-  val s3Client = {
-    if (accessKeys.length == 2)
-      new AmazonS3Client(new BasicAWSCredentials(accessKeys(0), accessKeys(1)))
-    else
+  val s3Client =
+    config.creds.map { c =>
+      new AmazonS3Client(c.awsApiCreds)
+    } getOrElse {
       new AmazonS3Client(new DefaultAWSCredentialsProviderChain())
-  }
+    }
 
   val getLiveSnapshot: String => S3Object = getObject(_, liveBucket)
   val getDraftSnapshot: String => S3Object = getObject(_, draftBucket)

--- a/cloudformation/restorer.json
+++ b/cloudformation/restorer.json
@@ -37,18 +37,6 @@
       "Description": "Ip range for the office",
       "Type": "String",
       "Default": "77.91.248.0/21"
-    },
-    "PandomainDomain": {
-      "Description": "master domain the app is on",
-      "Type": "String"
-    },
-    "PandomainAwsKey": {
-      "Description": "aws key for pandomain bucket access",
-      "Type": "String"
-    },
-    "PandomainAwsSecret": {
-      "Description": "aws secret for pandomain bucket access",
-      "Type": "String"
     }
   },
   "Mappings": {
@@ -452,11 +440,6 @@
                 "(cd /home/restorer; tar xvzf composer-restorer.tgz)\n",
                 "chown -R restorer /home/restorer\n",
                 "chgrp -R restorer /home/restorer\n",
-                "sed -i \\\n",
-                "    -e 's,@PANDOMAIN_DOMAIN@,", {"Ref": "PandomainDomain"}, ",g' \\\n",
-                "    -e 's,@PANDOMAIN_AWS_KEY@,", {"Ref": "PandomainAwsKey"}, ",g' \\\n",
-                "    -e 's,@PANDOMAIN_AWS_SECRET@,", {"Ref": "PandomainAwsSecret"}, ",g' \\\n",
-                "    /etc/init/composer-restorer.conf\n",
                 "start composer-restorer\n"
               ]
             ]

--- a/cloudformation/restorer.json
+++ b/cloudformation/restorer.json
@@ -137,6 +137,22 @@
         "Roles": [{"Ref": "RestorerRole"}]
       }
     },
+    "PanDomainPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "PanDomainPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::pan-domain-auth-settings/*"]
+            }
+          ]
+        },
+        "Roles": [{"Ref": "RestorerRole"}]
+      }
+    },
     "RestorerSnapshotBucketPolicy": {
       "Type": "AWS::IAM::Policy",
       "Properties": {

--- a/composer-restorer.conf
+++ b/composer-restorer.conf
@@ -21,10 +21,6 @@ env APP=restorer
 
 env LOGFILE=/home/restorer/logs/stdout.log
 
-env PANDOMAIN_DOMAIN=@PANDOMAIN_DOMAIN@
-env PANDOMAIN_AWS_KEY=@PANDOMAIN_AWS_KEY@
-env PANDOMAIN_AWS_SECRET=@PANDOMAIN_AWS_SECRET@
-
 script
 $USER_HOME/composer-restorer/bin/composer-restorer > $LOGFILE 2>&1
 end script

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,8 +61,4 @@ logger.play=INFO
 logger.application=DEBUG
 
 # Environment specific settings
-pandomain.domain=${?PANDOMAIN_DOMAIN}
-pandomain.aws.key=${?PANDOMAIN_AWS_KEY}
-pandomain.aws.secret=${?PANDOMAIN_AWS_SECRET}
-
 include "local.conf"

--- a/conf/routes
+++ b/conf/routes
@@ -26,4 +26,4 @@ OPTIONS        /*all                           controllers.Application.preflight
 
 # Health check
 GET /management/healthcheck                    controllers.Management.healthCheck
-GET /management/info                           controllers.Application.info
+GET /management/info                           controllers.Management.info


### PR DESCRIPTION
Instead of specifying the pandomain auth keys as CFN parameters, access to
the pandomain bucket is now allowed by using a new policy and giving explicit
permissions on the S3 bucket for the restorer role created by the CFN stack.

This PR also tidies up the way AWS credentials are optionally configured.