### PR TITLE
Whitelist: add more people to the whitelist

### DIFF
--- a/conf/whitelist.conf
+++ b/conf/whitelist.conf
@@ -20,10 +20,16 @@ whitelist {
       "tom.ross@guardian.co.uk",
       "madhvi.pankhania@guardian.co.uk",
 
+      # Le Restorer
+      "katherine.leruez@guardian.co.uk",
+
       # ESD
       "luke.hoyland@guardian.co.uk",
 
       # the boss
-      "david.blishen@guardian.co.uk"
+      "david.blishen@guardian.co.uk",
+
+      # the other boss
+      "robert.rees@guardian.co.uk"
     ]
 }

--- a/conf/whitelist.conf
+++ b/conf/whitelist.conf
@@ -9,6 +9,7 @@ whitelist {
       "jon.parsons@guardian.co.uk",
       "robert.phillips@guardian.co.uk",
       "neal.madlani@guardian.co.uk",
+      "alastair.jardine@guardian.co.uk",
 
       # central production
       "lydia.smears@guardian.co.uk",


### PR DESCRIPTION
Adds two vital but sadly overlooked team members who should be able to restore...

And Alistair.