### PR TITLE
Enable pre-PROD envs to use CODE via CORS

### DIFF
--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -38,6 +38,11 @@ object RestorerConfig extends AwsInstanceTags {
 
   val hostName: String = "https://composer-restorer." + domain
 
+  val corsableDomains = RestorerConfig.stage match {
+    case "PROD" | "DEV" => Seq(RestorerConfig.composerDomain)
+    case _ => Seq("release", "code", "qa").map(x => s"https://composer.$x.$domain")
+  }
+
   lazy val config = play.api.Play.configuration
 
   val accessKey: Option[String] = config.getString("AWS_ACCESS_KEY")

--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -40,7 +40,7 @@ object RestorerConfig extends AwsInstanceTags {
 
   val corsableDomains = RestorerConfig.stage match {
     case "PROD" | "DEV" => Seq(RestorerConfig.composerDomain)
-    case _ => Seq("release", "code", "qa").map(x => s"https://composer.$x.$domain")
+    case _ => Seq("release", "code", "qa").map(x => s"https://composer.$x.dev-gutools.co.uk")
   }
 
   lazy val config = play.api.Play.configuration

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -57,11 +57,11 @@ object Application extends Controller with PanDomainAuthActions {
 
   def preflight(routes: String) = CORSable(RestorerConfig.corsableDomains: _*) {
     Action { implicit req =>
-      val requestedHeaders = req.headers("Access-Control-Request-Headers")
+      val requestedHeaders = req.headers.get("Access-Control-Request-Headers")
 
       NoContent.withHeaders(
         CORSable.CORS_ALLOW_METHODS -> "GET, DELETE, PUT",
-        CORSable.CORS_ALLOW_HEADERS -> requestedHeaders)
+        CORSable.CORS_ALLOW_HEADERS -> requestedHeaders.getOrElse(""))
     }
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -55,7 +55,7 @@ object Application extends Controller with PanDomainAuthActions {
     )
   }
 
-  def preflight(routes: String) = CORSable(composer) {
+  def preflight(routes: String) = CORSable(RestorerConfig.corsableDomains: _*) {
     Action { implicit req =>
       val requestedHeaders = req.headers("Access-Control-Request-Headers")
 

--- a/app/controllers/Templates.scala
+++ b/app/controllers/Templates.scala
@@ -9,27 +9,25 @@ import org.joda.time.LocalDateTime
 import helpers.CORSable
 
 import models.Template
-import config.RestorerConfig
+import config.RestorerConfig.corsableDomains
 
 object Templates extends Controller with PanDomainAuthActions {
 
-  lazy val composer = RestorerConfig.composerDomain
-
-  def index = CORSable(composer) {
+  def index = CORSable(corsableDomains: _*) {
     Action {
       val res = Json.toJson(Template.retrieveAll())
       Ok(res)
     }
   }
 
-  def getTemplate(key: String) = CORSable(composer) {
+  def getTemplate(key: String) = CORSable(corsableDomains: _*) {
     Action {
       val res = Json.toJson(Template.retrieve(key))
       Ok(res)
     }
   }
 
-  def saveTemplate = CORSable(composer) {
+  def saveTemplate = CORSable(corsableDomains: _*) {
     Action(parse.json) { request =>
 
       val template = Template(

--- a/app/helpers/CORSable.scala
+++ b/app/helpers/CORSable.scala
@@ -11,7 +11,7 @@ case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
 
     val headers = request.headers.get("Origin").map { origin =>
       if(origins.contains(origin)) {
-        List("Access-Control-Allow-Origin" -> origin, "Access-Control-Allow-Credentials" -> "true")
+        List(CORSable.CORS_ALLOW_ORIGIN -> origin, CORSable.CORS_CREDENTIALS -> "true")
       } else { Nil }
     }
 


### PR DESCRIPTION
Enables Composer code, release, and qa environments to use template endpoints on Restorer CODE env via CORS.