### PR TITLE
Update Panda auth to 0.2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "composer-restorer"
 version := "0.0.1"
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "pan-domain-auth-play" % "0.2.3",
+  "com.gu" %% "pan-domain-auth-play" % "0.2.6",
   ws
 )
 


### PR DESCRIPTION
Updates panda auth to fix an issue with parsing user info due to an update by Google.