### PR TITLE
Version endpoint output with json mime type

### DIFF
--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -43,7 +43,7 @@ object Versions extends Controller with PanDomainAuthActions {
 
     val snapshot = if (isLive) s3.getLiveSnapshot(versionPath) else s3.getDraftSnapshot(versionPath)
 
-    Ok(snapShotAsString(snapshot))
+    Ok(snapShotAsString(snapshot)).as(JSON)
   }
 
   def showReadable(contentId: String, isLive: Boolean, versionId: String) = AuthAction {


### PR DESCRIPTION
Minor change sets the mime type of the versions endpoint to JSON so that our browsers can render them nicererer.

To test:
- View snapshots for an article
- Click of "JSON"
- If you have a json formatter installed in your browser, it will look nicererer.