### PR TITLE
Fix mixpanel tracking

### DIFF
--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -19,7 +19,9 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
     SnapshotModels
       .getCollection($routeParams.contentId)
       .then((collection)=> {
-        displayContent(collection.getModelAt(0));
+        var model = collection.getModelAt(0);
+        displayContent(model);
+        mediator.publish('mixpanel:view-snapshot', model);
       })
       //TODO setup global error handle
       .catch((err)=> mediator.publish('error', err));

--- a/public/javascripts/app/controllers/SnapshotListCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotListCtrl.js
@@ -74,7 +74,7 @@ SnapshotListCtrlMod.controller('SnapshotListCtrl', [
       //set active states
       activeModel.set('activeState', false);
       model.set('activeState', true);
-      mediator.publish('mixpanel:view-snapshot', model.getJSON());
+      mediator.publish('mixpanel:view-snapshot', model);
       //place the content
       $timeout(()=> mediator.publish('snapshot-list:display-content', model), 1);
     }

--- a/public/javascripts/app/services/MixpanelService.js
+++ b/public/javascripts/app/services/MixpanelService.js
@@ -46,7 +46,8 @@ MixpanelServiceMod.service('MixpanelService', [
     mediator.subscribe('mixpanel:view-snapshot', (modelData)=>{
       hasUser.then(()=> {
         var trackingData = {
-          'contentId': modelData.get('id')
+          'contentId': modelData.get('id'),
+          'snapshotTime': modelData.get('timestamp')
         };
         mixpanel.restorer.track('view-snapshot', trackingData);
       });
@@ -55,7 +56,8 @@ MixpanelServiceMod.service('MixpanelService', [
     mediator.subscribe('mixpanel:restore-snapshot', (modelData)=> {
       hasUser.then(() => {
         var trackingData = {
-          'contentId': modelData.get('id')
+          'contentId': modelData.get('id'),
+          'snapshotTime': modelData.get('timestamp')
         };
         mixpanel.restorer.track('restore-snapshot', trackingData);
       });

--- a/public/javascripts/app/services/MixpanelService.js
+++ b/public/javascripts/app/services/MixpanelService.js
@@ -45,19 +45,25 @@ MixpanelServiceMod.service('MixpanelService', [
 
     mediator.subscribe('mixpanel:view-snapshot', (modelData)=>{
       hasUser.then(()=> {
-        mixpanel.restorer.track('view-snapshot', modelData);
+        var trackingData = {
+          'contentId': modelData.get('id')
+        };
+        mixpanel.restorer.track('view-snapshot', trackingData);
       });
     });
 
     mediator.subscribe('mixpanel:restore-snapshot', (modelData)=> {
       hasUser.then(() => {
-        mixpanel.restorer.track('restore-snapshot', modelData);
+        var trackingData = {
+          'contentId': modelData.get('id')
+        };
+        mixpanel.restorer.track('restore-snapshot', trackingData);
       });
     });
 
     mediator.subscribe('mixpanel:copy-content', (content)=> {
       hasUser.then(() => {
-        mixpanel.restorer.track('copy-content', content);
+        mixpanel.restorer.track('copy-content');
       });
     });
   }

--- a/public/javascripts/app/services/RestoreService.js
+++ b/public/javascripts/app/services/RestoreService.js
@@ -26,7 +26,7 @@ var RestoreService = RestoreServiceMod.service('RestoreService', [
             .then((collection) => {
               //get model
               var model = collection.find((data)=> data.activeState);
-              mediator.publish('mixpanel:restore-snapshot', model.getJSON());
+              mediator.publish('mixpanel:restore-snapshot', model);
               //make the request
               $http({
                 url: restoreUrl,


### PR DESCRIPTION
Tracking events were attempting to pass through the entire article model, causing 413 errors. This PR just tracks the Composer ID and the timestamp of the snapshot viewed / restored. 