### PR TITLE
Close S3 input stream after reading in content

### DIFF
--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -27,7 +27,7 @@ object Versions extends Controller with PanDomainAuthActions with Loggable {
       // We use the last snapshot's headline.
       val snapshot = draftVersions.lastOption
       val headline = snapshot.flatMap { ss =>
-        (Json.parse(snapShotAsString(s3.getDraftSnapshot(ss.key))) \ "preview" \ "fields" \ "headline").asOpt[String]
+        (Json.parse(s3.getDraftSnapshot(ss.key)) \ "preview" \ "fields" \ "headline").asOpt[String]
       }
 
       Ok(views.html.Versions.index(contentId, draftVersions, headline getOrElse ""))
@@ -44,17 +44,13 @@ object Versions extends Controller with PanDomainAuthActions with Loggable {
 
     val snapshot = if (isLive) s3.getLiveSnapshot(versionPath) else s3.getDraftSnapshot(versionPath)
 
-    Ok(snapShotAsString(snapshot)).as(JSON)
+    Ok(snapshot).as(JSON)
   }
 
   def showReadable(contentId: String, isLive: Boolean, versionId: String) = AuthAction {
     val showActionPath = routes.Versions.show(contentId, isLive, versionId).url
     Ok(views.html.Versions.show(contentId, versionId, showActionPath))
 
-  }
-
-  def snapShotAsString(snapshot: S3Object) = {
-    Source.fromInputStream(snapshot.getObjectContent(), "UTF-8").mkString
   }
 
   def getJSONVersionsCollection(contentId: String) = AuthAction {
@@ -64,7 +60,7 @@ object Versions extends Controller with PanDomainAuthActions with Loggable {
     val draftVersions         = draftVersionKeys.map(Snapshot)
     val both = (draftVersionKeys, draftVersions).zipped
     val draftVersionsContent  = Json.toJson(both.map {(key, ss) =>
-      Map(timestamp(key).get -> (Json.parse(snapShotAsString(s3.getDraftSnapshot(ss.key)))))
+      Map(timestamp(key).get -> Json.parse(s3.getDraftSnapshot(ss.key)))
     })
 
     Ok(draftVersionsContent)

--- a/app/models/Template.scala
+++ b/app/models/Template.scala
@@ -43,10 +43,10 @@ object Template extends Loggable {
     val req = s3.objectRequest(bucket)
     val objects = s3.getObjects(req).getObjectSummaries.asScala.toList
     val keys = objects.map(x => x.getKey())
-    val results = keys.map(s3.getObject(_, bucket))
+    val results = keys.map(s3.getObjectContents(_, bucket))
     info("fetching all templates from: %s".format(bucket))
     results.map({ x =>
-      val json = Json.parse(Source.fromInputStream(x.getObjectContent(), "UTF-8").mkString)
+      val json = Json.parse(x)
       TemplateSummary(
         (json \ "title").as[String],
         (json \ "dateCreated").as[String])
@@ -55,8 +55,8 @@ object Template extends Loggable {
 
   def retrieve(id: String) = {
     info("retrieving template with id: %s".format(id))
-    val result = s3.getObject(id, bucket)
-    val json = Json.parse(Source.fromInputStream(result.getObjectContent(), "UTF-8").mkString)
+    val result = s3.getObjectContents(id, bucket)
+    val json = Json.parse(result)
     Template(
         (json \ "title").as[String],
         (json \ "dateCreated").as[String],


### PR DESCRIPTION
`/templates` was causing a bunch of `CLOSE_WAIT` states on the restorer boxes, blocking new S3 connections. This PR should force closing of all S3 input streams after the content has been parsed into a string.