### PR TITLE
Snapshot list: use 24 hour format

### DIFF
--- a/public/javascripts/app/models/SnapshotModel.js
+++ b/public/javascripts/app/models/SnapshotModel.js
@@ -21,7 +21,7 @@ SnapshotModelMod.factory('SnapshotModel', [
       }
 
       getCreatedDate(){
-        return this.get('createdDate').format('h:mm:ss D MMMM YYYY');
+        return this.get('createdDate').format('HH:mm:ss D MMMM YYYY');
       }
 
       getRelativeDate(date = moment()){


### PR DESCRIPTION
This change reflects a comment from KLR that the single digit was confusing and had caused confusion during an investigation into a problem.