### PR TITLE
Whitelist: additions: Readers Editor

### DIFF
--- a/conf/whitelist.conf
+++ b/conf/whitelist.conf
@@ -156,6 +156,14 @@ whitelist {
        "barbara.harpern@guardian.co.uk",
        "helen.hodgsonn@guardian.co.uk",
        "anna.clarke@guardian.co.uk",
-       "john.ives@guardian.co.uk"
+       "john.ives@guardian.co.uk",
+
+      # Readers Editor's desk
+
+      "rory.foster@guardian.co.uk",
+      "chris.elliott@guardian.co.uk",
+      "barbara.harper@guardian.co.uk",
+      "helen.hodgson@guardian.co.uk",
+      "anna.clarke@guardian.co.uk"
     ]
 }


### PR DESCRIPTION
Adds the members of the Readers Editor desk at the request of Central Production