### PR TITLE
Add route to give simple count of available versions

### DIFF
--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -58,5 +58,8 @@ object RestorerConfig extends AwsInstanceTags {
 
   val usePermissionsService: Boolean = config.getBoolean("permissions.enabled").getOrElse(true)
 
-  lazy val apiSharedSecret: Option[String] = config.getString("api.key")
+  lazy val apiSharedSecret: String = config.getString("api.sharedsecret") match {
+    Some(x) => x
+    None => throw new RuntimeException(s"No config value for: api.sharedsecret")
+  }
 }

--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -59,7 +59,7 @@ object RestorerConfig extends AwsInstanceTags {
   val usePermissionsService: Boolean = config.getBoolean("permissions.enabled").getOrElse(true)
 
   lazy val apiSharedSecret: String = config.getString("api.sharedsecret") match {
-    Some(x) => x
-    None => throw new RuntimeException(s"No config value for: api.sharedsecret")
+    case Some(x) => x
+    case None => throw new RuntimeException(s"No config value for: api.sharedsecret")
   }
 }

--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -48,7 +48,7 @@ object RestorerConfig extends AwsInstanceTags {
   val accessKey: Option[String] = config.getString("AWS_ACCESS_KEY")
   val secretKey: Option[String] = config.getString("AWS_SECRET_KEY")
   val creds = AWSCredentials(accessKey, secretKey)
-  
+
   val pandomainKey: Option[String] = config.getString("pandomain.aws.key")
   val pandomainSecret: Option[String] = config.getString("pandomain.aws.secret")
   val pandomainCreds = AWSCredentials(pandomainKey, pandomainSecret)
@@ -57,4 +57,6 @@ object RestorerConfig extends AwsInstanceTags {
   lazy val whitelistMembers: Set[String] = config.getStringSeq("whitelist.members").getOrElse(Nil).toSet
 
   val usePermissionsService: Boolean = config.getBoolean("permissions.enabled").getOrElse(true)
+
+  lazy val apiSharedSecret: Option[String] = config.getString("api.key")
 }

--- a/app/controllers/SharedSecretAuth.scala
+++ b/app/controllers/SharedSecretAuth.scala
@@ -1,0 +1,38 @@
+package controllers
+
+import java.util.Date
+import play.api.libs.Crypto.sign
+import scala.concurrent.Future
+import play.api.mvc._
+import scala.concurrent.ExecutionContext.Implicits.global
+import config.RestorerConfig
+
+object SharedSecretAuthAction extends ActionBuilder[Request] {
+
+  val devmode = true
+  val cookieName = "restorer-secret"
+  val sharedKey = RestorerConfig.apiSharedSecret.getOrElse("changeme").getBytes
+
+  val mask = Math.pow(2, 16).toLong - 1
+
+  // openssl sha1 -hmac "ABC"
+  def sharedSecret: Seq[String] = {
+    val code = ((new Date().getTime) & ~(mask))
+    // give some grace on either side
+    List(code - (mask + 1), code, code + (mask + 1)).map(time => sign(time.toString, sharedKey))
+  }
+
+  def matchesSharedSecret(candidate: String): Boolean = sharedSecret.exists({ x =>
+    println(s"comparing $x to $candidate"); x == candidate })
+
+
+  def isInOnTheSecret(req: Request[_]): Boolean =
+    req.cookies.get(cookieName).map(cookie => matchesSharedSecret(cookie.value)).getOrElse(false)
+
+  def invokeBlock[A](req: Request[A], block: (Request[A]) => Future[Result]) =
+    if(!isInOnTheSecret(req))
+      Future(Results.Forbidden)
+    else
+      block(req)
+
+}

--- a/app/controllers/SharedSecretAuth.scala
+++ b/app/controllers/SharedSecretAuth.scala
@@ -11,7 +11,7 @@ object SharedSecretAuthAction extends ActionBuilder[Request] {
 
   val devmode = true
   val cookieName = "restorer-secret"
-  val sharedKey = RestorerConfig.apiSharedSecret.getOrElse("changeme").getBytes
+  val sharedKey = RestorerConfig.apiSharedSecret.getBytes
 
   val mask = Math.pow(2, 16).toLong - 1
 

--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -66,4 +66,13 @@ object Versions extends Controller with PanDomainAuthActions with Loggable {
     Ok(draftVersionsContent)
   }
 
+
+  case class VersionCount(id: String, versionCount: Int)
+  object VersionCount { implicit val jsonFormats = Json.format[VersionCount]}
+  def availableVersionsCount(contentId: String) = SharedSecretAuthAction {
+    val s3 = new S3
+    val count = VersionCount(contentId, s3.listDraftForId(contentId).size)
+    Ok(Json.toJson(count))
+  }
+
 }

--- a/cloudformation/restorer.json
+++ b/cloudformation/restorer.json
@@ -440,6 +440,14 @@
                 ]]},
                 "authentication": "distributionAuthentication"
               },
+                "/etc/gu/restorer-secrets.conf": {
+                    "source": { "Fn::Join" : ["", [
+                        "https://s3-eu-west-1.amazonaws.com/composer-dist/flexible/",
+                        { "Ref": "Stage" },
+                        "/restorer/restorer-secrets.conf"
+                    ]]},
+                    "authentication": "distributionAuthentication"
+                },
               "/home/restorer/restorer.tgz": {
                 "source": {
                   "Fn::Join": [

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,9 @@ logger.application=DEBUG
 
 permissions.enabled=true
 
+# the secret file
+include file("/etc/gu/restorer-secrets.conf")
+
 # Environment specific settings
 include "local.conf"
 include "whitelist.conf"

--- a/conf/routes
+++ b/conf/routes
@@ -33,3 +33,4 @@ GET            /management/info                            controllers.Managemen
 # API
 GET           /api/1/versions/:contentId                   controllers.Versions.getJSONVersionsCollection(contentId: String)
 GET           /api/1/user                                  controllers.Login.user
+GET           /api/1/version-count/:contentId              controllers.Versions.availableVersionsCount(contentId: String)


### PR DESCRIPTION
This uses a shared secret to give a simple route to let a user use a shared secret to see how many versions there are available for a given composer id