### PR TITLE
CORS: add local to accepted CORS domains

### DIFF
--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -29,9 +29,11 @@ object RestorerConfig extends AwsInstanceTags {
 
   val hostName: String = "https://composer-restorer." + domain
 
+  val validPreProductionEnvironments = Set("release", "code", "qa", "local")
+
   val corsableDomains = RestorerConfig.stage match {
     case "PROD" | "DEV" => Seq(RestorerConfig.composerDomain)
-    case _ => Seq("release", "code", "qa").map(x => s"https://composer.$x.dev-gutools.co.uk")
+    case _ => validPreProductionEnvironments.map(x => s"https://composer.$x.dev-gutools.co.uk")
   }
 
   lazy val config = play.api.Play.configuration

--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -29,7 +29,7 @@ object RestorerConfig extends AwsInstanceTags {
 
   val hostName: String = "https://composer-restorer." + domain
 
-  val validPreProductionEnvironments = Set("release", "code", "qa", "local")
+  val validPreProductionEnvironments = Seq("release", "code", "qa", "local")
 
   val corsableDomains = RestorerConfig.stage match {
     case "PROD" | "DEV" => Seq(RestorerConfig.composerDomain)


### PR DESCRIPTION
Add local to set of acceptable preproduction environments.

We want development environments to be able to connect to the code instances