### PR TITLE
Move action buttons and hide restorer button based on permissions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.scala]
+indent_size = 2

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -64,6 +64,10 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
       }
   }
 
+      this.restoreContent = function() {
+          mediator.publish('snapshot-list:display-modal');
+      }
+
   }
 
 ]);

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -11,10 +11,21 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
   '$timeout',
   '$sce',
   'SnapshotModels',
-  function($scope, $routeParams, $timeout, $sce, SnapshotModels){
+    'UserService',
+  function($scope, $routeParams, $timeout, $sce, SnapshotModels, UserService){
 
     $scope.isShowingJSON = false;
-      $scope.displayButtonLabel = "JSON";
+    $scope.displayButtonLabel = "JSON";
+    $scope.canRestore =  UserService.get().then((user) => {
+        if(user.permissions && user.permissions.restoreContent) {
+          return true;
+        }
+        return false;
+    }).catch ((err) => {
+        //send the error via the mediator
+        mediator.publish('error', err);
+        return false;
+    });
 
     //set the initial content
     SnapshotModels

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -16,15 +16,16 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
 
     $scope.isShowingJSON = false;
     $scope.displayButtonLabel = "JSON";
-    $scope.canRestore =  UserService.get().then((user) => {
-        if(user.permissions && user.permissions.restoreContent) {
-          return true;
+    $scope.canRestore =  false;
+
+    UserService.get().then((user) => {
+        if(user.permissions && user.permissions.restoreContent && user.permissions.restoreContent === true) {
+          $scope.canRestore = true;
         }
-        return false;
     }).catch ((err) => {
         //send the error via the mediator
+        console.log('error', err);
         mediator.publish('error', err);
-        return false;
     });
 
     //set the initial content

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -14,6 +14,7 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
   function($scope, $routeParams, $timeout, $sce, SnapshotModels){
 
     $scope.isShowingJSON = false;
+      $scope.displayButtonLabel = "JSON";
 
     //set the initial content
     SnapshotModels
@@ -49,6 +50,19 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
     function displayHTML() {
       safeApply($scope, () => $scope.isShowingJSON = false);
     }
+
+  this.toggleJSON = function() {
+      if ($scope.isShowingJSON) {
+          mediator.publish('snapshot-list:display-html');
+          $scope.isShowingJSON = false;
+          $scope.displayButtonLabel = "JSON";
+
+      } else {
+          mediator.publish('snapshot-list:display-json');
+          $scope.isShowingJSON = true;
+          $scope.displayButtonLabel = "TEXT";
+      }
+  }
 
   }
 

--- a/public/javascripts/app/controllers/SnapshotListInteractionCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotListInteractionCtrl.js
@@ -33,18 +33,6 @@ SnapshotListInteractionCtrlMod.controller('SnapshotListInteractionCtrl', [
       mediator.publish('snapshot-list:set-active', index);
     };
 
-    // DISPLAY MODAL
-    this.onRestoreClicked = function(){
-      setState('modal');
-      mediator.publish('snapshot-list:display-modal');
-    };
-
-    // DISPLAY JSON VIEW
-    this.onJSONClicked = function(){
-      setState('json');
-      mediator.publish('snapshot-list:display-json');
-    };
-
     window.addEventListener('copy', function(e){
       // get the selected content
       var selection = window.getSelection();

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -99,37 +99,6 @@
                             {{model.getPublishedState()}}
                         </div>
                     </div>
-
-                    <div class="snapshot-list__item__buttons"
-                         ng-show="model.get('activeState') && hovered">
-                        <!-- JSON LINK -->
-                        <!-- DUE TO THE NATURE OF THE HOVER EFFECTS WE NEED TO CANCEL
-                             THE BACKGROUND COLOR WHEN THE RESTORE BUTTON IS ACTIVE
-                             THIS IS WHY THIS IS THE ONLY BUTTON WITH AN 'in-active' CLASS
-                             JP 13/4/15
-                           -->
-                        <gu-btn class="snapshot-list__item__json"
-                                href="#"
-                                variant="light"
-                                ng-class="{ hidden: !model.get('activeState'), 'active': isDisplayingJSON, 'in-active': isDisplayingModal }"
-                                ng-click="ctrl.onJSONClicked()">
-                            JSON
-                        </gu-btn>
-
-                        <!-- RESTORE LINK -->
-                        <div ng-if="isAbleToRestore()">
-                            <gu-btn class="snapshot-list__item__restore"
-                                    href="#"
-                                    variant="light"
-                                    ng-class="{ hidden: !model.get('activeState'), 'active': isDisplayingModal }"
-                                    ng-click="ctrl.onRestoreClicked()">
-                                <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
-                                Restore
-                            </gu-btn>
-                        </div>
-
-
-                    </div>
                 </div>
 
             </gu-index-list-item>
@@ -159,7 +128,7 @@
                 <gu-btn class="snapshot-content__actions--button"
                 ng-click="ctrl.restoreContent()"
                 ng-if="ctrl.canRestore">
-                    <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
+                    <gu-icon class="snapshot-content__actions__restore__icon" variant="wrench-disabled"></gu-icon>
                     Restore
                 </gu-btn>
                 <gu-btn class="snapshot-content__actions--button"

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -157,7 +157,8 @@
 
             <gu-row class="snapshot-content__actions">
                 <gu-btn class="snapshot-content__actions--button"
-                ng-click="ctrl.restoreContent()">
+                ng-click="ctrl.restoreContent()"
+                ng-if="ctrl.canRestore">
                     <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
                     Restore
                 </gu-btn>

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -127,7 +127,7 @@
             <gu-row class="snapshot-content__actions">
                 <gu-btn class="snapshot-content__actions--button"
                 ng-click="ctrl.restoreContent()"
-                ng-if="ctrl.canRestore">
+                ng-if="canRestore">
                     <gu-icon class="snapshot-content__actions__restore__icon" variant="wrench-disabled"></gu-icon>
                     Restore
                 </gu-btn>

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -156,7 +156,8 @@
         <div class="snapshot-content__viewport">
 
             <gu-row class="snapshot-content__actions">
-                <gu-btn class="snapshot-content__actions--button">
+                <gu-btn class="snapshot-content__actions--button"
+                ng-click="ctrl.restoreContent()">
                     <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
                     Restore
                 </gu-btn>

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -156,6 +156,10 @@
         <div class="snapshot-content__viewport">
 
             <gu-row class="snapshot-content__actions">
+                <gu-btn class="snapshot-content__actions--button">
+                    <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
+                    Restore
+                </gu-btn>
                 <gu-btn class="snapshot-content__actions--button"
                 ng-click="ctrl.toggleJSON()">{{displayButtonLabel}}</gu-btn>
             </gu-row>

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -1,19 +1,19 @@
 <!-- ERROR STATUS -->
-<div  style="display: none"
-      class="modal center"
-      ng-controller="ErrorCtrl as errorCtrl"
-      ng-class="{ 'visually-hidden': !errorCtrl.hasError }">
-  <gu-box class="modal__content" variant="primary">
-    <gu-row class="modal__content__form__fieldset">
-      <gu-column span="12">
-        <h1 class="modal__content__title">Ooops, something went wrong</h1>
-        {{ errorCtrl.errorContent }}
-      </gu-column>
-    </gu-row>
-    <gu-row variant="reverse" class="modal__content__form__fieldset">
-      <!-- TODO ADD BACK TO COMPOSER BUTTON JP 15/4/15 -->
-    </gu-row>
-  </gu-box>
+<div style="display: none"
+     class="modal center"
+     ng-controller="ErrorCtrl as errorCtrl"
+     ng-class="{ 'visually-hidden': !errorCtrl.hasError }">
+    <gu-box class="modal__content" variant="primary">
+        <gu-row class="modal__content__form__fieldset">
+            <gu-column span="12">
+                <h1 class="modal__content__title">Ooops, something went wrong</h1>
+                {{ errorCtrl.errorContent }}
+            </gu-column>
+        </gu-row>
+        <gu-row variant="reverse" class="modal__content__form__fieldset">
+            <!-- TODO ADD BACK TO COMPOSER BUTTON JP 15/4/15 -->
+        </gu-row>
+    </gu-box>
 </div>
 
 <!-- HEADER -->
@@ -21,255 +21,270 @@
 
 <!-- PRELOADER -->
 <div ng-if="isLoading">
-  <gu-loading-bars></gu-loading-bars>
+    <gu-loading-bars></gu-loading-bars>
 </div>
 
 <gu-row ng-if="!isLoading" class="content">
-  <gu-column  class="sidebar"
-              span="4"
-              gu-box="secondary"
-              ng-class="{'active': isSidebarActive}"
-              ng-controller="SnapshotListInteractionCtrl as ctrl">
+    <gu-column class="sidebar"
+               span="4"
+               gu-box="secondary"
+               ng-class="{'active': isSidebarActive}"
+               ng-controller="SnapshotListInteractionCtrl as ctrl">
 
-    <!-- SNAPSHOT LIST HEADER -->
-    <h1 class="article-headline">{{ articleTitle }}</h1>
-    <h6 class="article-hash">
-        (<a href="{{articleURL}}" target="_blank">
+        <!-- SNAPSHOT LIST HEADER -->
+        <h1 class="article-headline">{{ articleTitle }}</h1>
+        <h6 class="article-hash">
+            (<a href="{{articleURL}}" target="_blank">
             {{ articleHash }}
         </a>)
-    </h6>
+        </h6>
 
-    <gu-row class="snapshot-list-header">
-      <span class="snapshot-list-header__decal">No.</span>
-      <span class="snapshot-list-header__content">Snapped at &amp; last modified</span>
-      <span class="snapshot-list-header__status">Status</span>
+        <gu-row class="snapshot-list-header">
+            <span class="snapshot-list-header__decal">No.</span>
+            <span class="snapshot-list-header__content">Snapped at &amp; last modified</span>
+            <span class="snapshot-list-header__status">Status</span>
 
-    </gu-row>
+        </gu-row>
 
-    <!-- SNAPSHOT LIST -->
-    <gu-index-list class="snapshot-list">
-      <gu-index-list-item variant="{{ model.get('activeState') ? 'tertiary' : 'primary' }}"
-                          class="snapshot-list__item"
-                          ng-repeat-start="model in models"
-                          ng-mouseenter="hovered=true"
-                          ng-mouseleave="hovered=false"
-                          index="{{ models.length - $index }}"
-                          ng-class="{ 'item-active': model.get('activeState') }">
-        <!-- CONTENT -->
-        <div  class="snapshot-list__item__content"
-              ng-class="{ 'active': model.get('activeState') && isDisplayingHTML }"
-              ng-click="ctrl.onItemClicked($index)">
-          <h6 class="snapshot-list__item__content__relative-date">{{ model.getRelativeDate() }} ago</h6>
-          <h6 class="snapshot-list__item__content__actual-date">{{ model.getCreatedDate() }}</h6>
-        </div>
+        <!-- SNAPSHOT LIST -->
+        <gu-index-list class="snapshot-list">
+            <gu-index-list-item variant="{{ model.get('activeState') ? 'tertiary' : 'primary' }}"
+                                class="snapshot-list__item"
+                                ng-repeat-start="model in models"
+                                ng-mouseenter="hovered=true"
+                                ng-mouseleave="hovered=false"
+                                index="{{ models.length - $index }}"
+                                ng-class="{ 'item-active': model.get('activeState') }">
+                <!-- CONTENT -->
+                <div class="snapshot-list__item__content"
+                     ng-class="{ 'active': model.get('activeState') && isDisplayingHTML }"
+                     ng-click="ctrl.onItemClicked($index)">
+                    <h6 class="snapshot-list__item__content__relative-date">{{ model.getRelativeDate() }} ago</h6>
+                    <h6 class="snapshot-list__item__content__actual-date">{{ model.getCreatedDate() }}</h6>
+                </div>
+                <div class="snapshot-list__item__information">
+                    <div class="snapshot-list__item__status"
+                         ng-click="ctrl.onItemClicked($index)"
+                         ng-if="(!model.get('activeState') && !hovered) || (model.get('activeState') && !hovered) || (hovered && !model.get('activeState'))">
+                        <div class="snapshot-list__item__status--left"
+                             ng-click="ctrl.onItemClicked($index)">
 
-        <div class="snapshot-list__item__status"
-             ng-click="ctrl.onItemClicked($index)"
-             ng-show="(!model.get('activeState') && !hovered) || (model.get('activeState') && !hovered) || (hovered && !model.get('activeState'))">
-            <div class="snapshot-list__item__status--left"
-                 ng-click="ctrl.onItemClicked($index)">
+                            <div class="snapshot-list__item__settings__legally-sensitive"
+                                 ng-show="model.isLegallySensitive()">
+                            </div>
 
-                <div class="snapshot-list__item__settings__legally-sensitive"
-                     ng-show="model.isLegallySensitive()">
+                            <div class="snapshot-list__item__settings__comments--on"
+                                 ng-show="model.commentsEnabled().on">
+                                <div class="snapshot-list__item__settings__comments--on-image">
+                                </div>
+                                <div class="snapshot-list__item__settings__content--text">
+                                    on
+                                </div>
+                            </div>
+
+                            <div class="snapshot-list__item__settings__comments--off"
+                                 ng-show="model.commentsEnabled().defined && !model.commentsEnabled().on">
+                                <div class="snapshot-list__item__settings__comments--off-image">
+                                </div>
+                                <div class="snapshot-list__item__settings__content--text">
+                                    off
+                                </div>
+                            </div>
+
+                        </div>
+
+                        <div class="snapshot-list__item__status--right"
+                             ng-click="ctrl.onItemClicked($index)"
+                             ng-show="!!model.getPublishedState()">
+                            {{model.getPublishedState()}}
+                        </div>
+                    </div>
+
+                    <div class="snapshot-list__item__buttons"
+                         ng-show="model.get('activeState') && hovered">
+                        <!-- JSON LINK -->
+                        <!-- DUE TO THE NATURE OF THE HOVER EFFECTS WE NEED TO CANCEL
+                             THE BACKGROUND COLOR WHEN THE RESTORE BUTTON IS ACTIVE
+                             THIS IS WHY THIS IS THE ONLY BUTTON WITH AN 'in-active' CLASS
+                             JP 13/4/15
+                           -->
+                        <gu-btn class="snapshot-list__item__json"
+                                href="#"
+                                variant="light"
+                                ng-class="{ hidden: !model.get('activeState'), 'active': isDisplayingJSON, 'in-active': isDisplayingModal }"
+                                ng-click="ctrl.onJSONClicked()">
+                            JSON
+                        </gu-btn>
+
+                        <!-- RESTORE LINK -->
+                        <div ng-if="isAbleToRestore()">
+                            <gu-btn class="snapshot-list__item__restore"
+                                    href="#"
+                                    variant="light"
+                                    ng-class="{ hidden: !model.get('activeState'), 'active': isDisplayingModal }"
+                                    ng-click="ctrl.onRestoreClicked()">
+                                <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
+                                Restore
+                            </gu-btn>
+                        </div>
+
+
+                    </div>
                 </div>
 
-                <div class="snapshot-list__item__settings__comments--on"
-                     ng-show="model.commentsEnabled().on">
-                    <div class="snapshot-list__item__settings__comments--on-image">
-                    </div>
-                    <div class="snapshot-list__item__settings__content--text">
-                        on
-                    </div>
-                </div>
+            </gu-index-list-item>
 
-                <div class="snapshot-list__item__settings__comments--off"
-                     ng-show="model.commentsEnabled().defined && !model.commentsEnabled().on">
-                    <div class="snapshot-list__item__settings__comments--off-image">
-                    </div>
-                    <div class="snapshot-list__item__settings__content--text">
-                        off
-                    </div>
-                </div>
-
-            </div>
-
-            <div class="snapshot-list__item__status--right"
-                 ng-click="ctrl.onItemClicked($index)"
-                 ng-show="!!model.getPublishedState()">
-                {{model.getPublishedState()}}
-            </div>
-        </div>
-
-        <div class="snapshot-list__item__buttons"
-             ng-show="model.get('activeState') && hovered">
-        <!-- JSON LINK -->
-        <!-- DUE TO THE NATURE OF THE HOVER EFFECTS WE NEED TO CANCEL
-             THE BACKGROUND COLOR WHEN THE RESTORE BUTTON IS ACTIVE
-             THIS IS WHY THIS IS THE ONLY BUTTON WITH AN 'in-active' CLASS
-             JP 13/4/15
-           -->
-        <gu-btn class="snapshot-list__item__json"
-                href="#"
-                variant="light"
-                ng-class="{ hidden: !model.get('activeState'), 'active': isDisplayingJSON, 'in-active': isDisplayingModal }"
-                ng-click="ctrl.onJSONClicked()">
-            JSON
-        </gu-btn>
-
-        <!-- RESTORE LINK -->
-        <gu-btn class="snapshot-list__item__restore"
-                href="#"
-                variant="light"
-                ng-class="{ hidden: !model.get('activeState'), 'active': isDisplayingModal }"
-                ng-click="ctrl.onRestoreClicked()">
-            <gu-icon class="snapshot-list__item__restore__icon" variant="wrench-disabled"></gu-icon>
-            Restore
-        </gu-btn>
-
-
-        </div>
-
-      </gu-index-list-item>
-
-      <!-- DELTA TIME -->
-      <li class="delta-row" ng-repeat-end ng-mouseover="isActive = true" ng-mouseout="isActive = false">
-        <gu-row variant="reverse">
-          <gu-icon class="delta-row__icon" variant="expand-disabled"></gu-icon>
+            <!-- DELTA TIME -->
+            <li class="delta-row" ng-repeat-end ng-mouseover="isActive = true" ng-mouseout="isActive = false">
+                <gu-row variant="reverse">
+                    <gu-icon class="delta-row__icon" variant="expand-disabled"></gu-icon>
           <span class="delta-row__content" ng-class="{ 'visually-hidden': !isActive }">
             {{ model.getRelativeDate( models[$index + 1].get('createdDate') ) }}
           </span>
-        </gu-row>
-      </li>
-
-    </gu-index-list>
-
-  </gu-column>
-
-  <!-- CONTENT -->
-  <gu-column  class="snapshot-content"
-              span="8"
-              ng-controller="SnapshotContentCtrl as ctrl"
-              ng-class="{'active': isSettingContent === false}">
-    <div class="snapshot-content__viewport">
-
-        <div class="snapshot-content__furniture">
-            <gu-row class="snapshot-content__furniture__item">
-                <h4 class="snapshot-content__furniture__item--header">
-                    Headline
-                </h4>
-                <p class="snapshot-content__furniture__item--content">
-                    {{ headline }}
-                </p>
-            </gu-row>
-
-            <gu-row class="snapshot-content__furniture__item">
-                <h4 class="snapshot-content__furniture__item--header">
-                    Standfirst
-                </h4>
-                <p class="snapshot-content__furniture__item--content">
-                    {{ standfirst }}
-                </p>
-            </gu-row>
-        </div>
-
-      <!-- TODO JP 15/4/15 Replace with accordion from components repo -->
-      <gu-row class="snapshot-content__container" ng-class="{ 'show-json': isShowingJSON }">
-
-        <!-- HTML CONTENT -->
-        <gu-column class="snapshot-content__container__item" span="6">
-          <div ng-bind-html="htmlContent"></div>
-        </gu-column>
-
-        <!-- JSON CONTENT -->
-        <gu-column span="6" class="snapshot-content__container__item--json">
-          <div><pre><code>{{ jsonContent }}</code></pre></div>
-        </gu-column>
-
-      </gu-row>
-    </div>
-  </gu-column>
-
-  <!-- MODAL -->
-  <!-- TODO JP 15/4/15 Replace with modal from components repo-->
-  <!-- INLINE STYLE TO AVOID INITIAL FLASH OF CONTENT WITH THE MODAL -->
-  <div style="display: none"
-       class="modal center"
-       ng-controller="ModalCtrl as modalCtrl"
-       ng-class="{ 'visually-hidden': !isActive }">
-    <gu-box class="modal__content" variant="primary">
-      <form novalidate class="modal-form" ng-controller="RestoreFormCtrl as formCtrl" ng-submit="formCtrl.onSubmit()">
-        <div class="modal__content__track">
-          <gu-row>
-            <!-- TODO JP 15/4/15 replace with accordion from components repo -->
-            <gu-column ng-class="{ 'in-active': isLoading }" class="form-panel" span="6">
-
-              <!-- MODAL HEADER -->
-              <gu-row>
-                <gu-column span="12">
-                  <h1 class="modal__content__title">Before you restore</h1>
-                  <!--commented as we are going to add presence support at a later date
-                    jp 13/04/2015
-                    <p class="modal__content__desc">Currently present in the content</p>
-                  -->
-                </gu-column>
-              </gu-row>
-
-              <!-- PRESENCE -->
-              <!--commented as we are going to add presence support at a later date
-                jp 13/04/2015
-                <gu-row class="modal__content__container">
-                <gu-column span="9">
-                some people
-                </gu-column>
-                <gu-column span="3">
-                <a class="model__content__refresh">
-                <gu-icon variant="expand-active"></gu-icon>
-                Refresh
-                </a>
-                </gu-column>
                 </gu-row>
-              -->
+            </li>
 
-              <!-- FORM -->
-              <gu-row class="modal__content__container">
-                <gu-column span="12" class="modal__content__form">
-                  <h2 class="modal__content__form__header">Make sure that:</h2>
-                  <gu-row class="modal__content__form__fieldset">
-                    <label for="self-in-content">
-                      <input type="checkbox" ng-model="selfInContent" name="selfInContent" id="self-in-content" />
-                      <span class="checked-decal"></span>
-                      <span class="label">You are not in content</span>
-                    </label>
-                  </gu-row>
-                  <gu-row class="modal__content__form__fieldset">
-                    <label for="else-in-content">
-                      <input type="checkbox" ng-model="elseInContent" name="elseInContent" id="else-in-content" />
-                      <span class="checked-decal"></span>
-                      <span class="label">No one else is in the content</span>
-                    </label>
-                  </gu-row>
+        </gu-index-list>
+
+    </gu-column>
+
+    <!-- CONTENT -->
+    <gu-column class="snapshot-content"
+               span="8"
+               ng-controller="SnapshotContentCtrl as ctrl"
+               ng-class="{'active': isSettingContent === false}">
+        <div class="snapshot-content__viewport">
+
+            <gu-row class="snapshot-content__actions">
+                <gu-btn class="snapshot-content__actions--button">JSON</gu-btn>
+            </gu-row>
+
+            <div class="snapshot-content__furniture">
+                <gu-row class="snapshot-content__furniture__item">
+                    <h4 class="snapshot-content__furniture__item--header">
+                        Headline
+                    </h4>
+                    <p class="snapshot-content__furniture__item--content">
+                        {{ headline }}
+                    </p>
+                </gu-row>
+
+                <gu-row class="snapshot-content__furniture__item">
+                    <h4 class="snapshot-content__furniture__item--header">
+                        Standfirst
+                    </h4>
+                    <p class="snapshot-content__furniture__item--content">
+                        {{ standfirst }}
+                    </p>
+                </gu-row>
+            </div>
+
+            <!-- TODO JP 15/4/15 Replace with accordion from components repo -->
+            <gu-row class="snapshot-content__container" ng-class="{ 'show-json': isShowingJSON }">
+
+                <!-- HTML CONTENT -->
+                <gu-column class="snapshot-content__container__item" span="6">
+                    <div ng-bind-html="htmlContent"></div>
                 </gu-column>
-              </gu-row>
 
-              <!-- ACTIONS -->
-              <gu-row variant="reverse" class="modal__content__container">
-                <gu-btn variant="active" class="modal__content__btn" type="submit" ng-disabled="!selfInContent || !elseInContent">
-                  <gu-icon variant="wrench-disabled"></gu-icon>
-                  Restore Version
-                </gu-btn>
-                <gu-btn class="modal__content__btn--close" type="reset" ng-click="modalCtrl.closeModal()">Cancel</gu-btn>
-              </gu-row>
+                <!-- JSON CONTENT -->
+                <gu-column span="6" class="snapshot-content__container__item--json">
+                    <div>
+                        <pre><code>{{ jsonContent }}</code></pre>
+                    </div>
+                </gu-column>
 
-            </gu-column>
-
-            <!-- LOADER -->
-            <gu-column span="6" class="form-loading"  ng-class="{ 'in-active': isLoading }" >
-              <gu-loading-bars></gu-loading-bars>
-            </gu-column>
-          </gu-row>
+            </gu-row>
         </div>
-      </form>
-    </gu-box>
-  </div>
+    </gu-column>
+
+    <!-- MODAL -->
+    <!-- TODO JP 15/4/15 Replace with modal from components repo-->
+    <!-- INLINE STYLE TO AVOID INITIAL FLASH OF CONTENT WITH THE MODAL -->
+    <div style="display: none"
+         class="modal center"
+         ng-controller="ModalCtrl as modalCtrl"
+         ng-class="{ 'visually-hidden': !isActive }">
+        <gu-box class="modal__content" variant="primary">
+            <form novalidate class="modal-form" ng-controller="RestoreFormCtrl as formCtrl"
+                  ng-submit="formCtrl.onSubmit()">
+                <div class="modal__content__track">
+                    <gu-row>
+                        <!-- TODO JP 15/4/15 replace with accordion from components repo -->
+                        <gu-column ng-class="{ 'in-active': isLoading }" class="form-panel" span="6">
+
+                            <!-- MODAL HEADER -->
+                            <gu-row>
+                                <gu-column span="12">
+                                    <h1 class="modal__content__title">Before you restore</h1>
+                                    <!--commented as we are going to add presence support at a later date
+                                      jp 13/04/2015
+                                      <p class="modal__content__desc">Currently present in the content</p>
+                                    -->
+                                </gu-column>
+                            </gu-row>
+
+                            <!-- PRESENCE -->
+                            <!--commented as we are going to add presence support at a later date
+                              jp 13/04/2015
+                              <gu-row class="modal__content__container">
+                              <gu-column span="9">
+                              some people
+                              </gu-column>
+                              <gu-column span="3">
+                              <a class="model__content__refresh">
+                              <gu-icon variant="expand-active"></gu-icon>
+                              Refresh
+                              </a>
+                              </gu-column>
+                              </gu-row>
+                            -->
+
+                            <!-- FORM -->
+                            <gu-row class="modal__content__container">
+                                <gu-column span="12" class="modal__content__form">
+                                    <h2 class="modal__content__form__header">Make sure that:</h2>
+                                    <gu-row class="modal__content__form__fieldset">
+                                        <label for="self-in-content">
+                                            <input type="checkbox" ng-model="selfInContent" name="selfInContent"
+                                                   id="self-in-content"/>
+                                            <span class="checked-decal"></span>
+                                            <span class="label">You are not in content</span>
+                                        </label>
+                                    </gu-row>
+                                    <gu-row class="modal__content__form__fieldset">
+                                        <label for="else-in-content">
+                                            <input type="checkbox" ng-model="elseInContent" name="elseInContent"
+                                                   id="else-in-content"/>
+                                            <span class="checked-decal"></span>
+                                            <span class="label">No one else is in the content</span>
+                                        </label>
+                                    </gu-row>
+                                </gu-column>
+                            </gu-row>
+
+                            <!-- ACTIONS -->
+                            <gu-row variant="reverse" class="modal__content__container">
+                                <gu-btn variant="active" class="modal__content__btn" type="submit"
+                                        ng-disabled="!selfInContent || !elseInContent">
+                                    <gu-icon variant="wrench-disabled"></gu-icon>
+                                    Restore Version
+                                </gu-btn>
+                                <gu-btn class="modal__content__btn--close" type="reset"
+                                        ng-click="modalCtrl.closeModal()">Cancel
+                                </gu-btn>
+                            </gu-row>
+
+                        </gu-column>
+
+                        <!-- LOADER -->
+                        <gu-column span="6" class="form-loading" ng-class="{ 'in-active': isLoading }">
+                            <gu-loading-bars></gu-loading-bars>
+                        </gu-column>
+                    </gu-row>
+                </div>
+            </form>
+        </gu-box>
+    </div>
 
 </gu-row>

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -156,7 +156,8 @@
         <div class="snapshot-content__viewport">
 
             <gu-row class="snapshot-content__actions">
-                <gu-btn class="snapshot-content__actions--button">JSON</gu-btn>
+                <gu-btn class="snapshot-content__actions--button"
+                ng-click="ctrl.toggleJSON()">{{displayButtonLabel}}</gu-btn>
             </gu-row>
 
             <div class="snapshot-content__furniture">

--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -40,7 +40,7 @@
 }
 
 .snapshot-content__furniture {
-    border-bottom: 1px solid rgba(162, 160, 160, 0.49);
+    @include thin-bottom-border;
 }
 
 .snapshot-content__furniture__item {
@@ -63,4 +63,18 @@
     display: flex;
     padding: 2% 5%;
     justify-content: flex-end;
+    space-between: 1rem;
+    @include thin-bottom-border;
+}
+
+.snapshot-content__actions--button {
+    display: flex;
+    height: 2.5rem;
+    margin-right: 1rem;
+    align-items: center;
+    justify-content: center;
+    background: $box-tertiary-bg;
+    & :last-child {
+        margin-right: 0;
+    }
 }

--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -78,3 +78,7 @@
         margin-right: 0;
     }
 }
+
+.snapshot-content__actions__restore__icon {
+    margin-right: 5px;
+}

--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -58,3 +58,9 @@
         color: $color-650-grey;
     }
 }
+
+.snapshot-content__actions {
+    display: flex;
+    padding: 2% 5%;
+    justify-content: flex-end;
+}

--- a/public/sass/components/snapshot-list.scss
+++ b/public/sass/components/snapshot-list.scss
@@ -107,8 +107,7 @@
 }
 
 .snapshot-list__item__buttons {
-  position: absolute;
-  right: 0%;
+  display: flex;
   height: 4.5em;
   font-weight: 500;
   z-index: 2;
@@ -205,8 +204,6 @@ div.index-list__item__index {
 // RESTORE BUTTON
 a.snapshot-list__item__restore {
   display: flex;
-  float: right;
-  width: 50%;
   height: 4.5em;
   align-items: center;
   justify-content: center;
@@ -226,10 +223,7 @@ a.snapshot-list__item__restore {
 
 //JSON BUTTON
 a.snapshot-list__item__json {
-  display: flex;
-  float: left;
   height: 4.5em;
-  width: 50%;
   align-items: center;
   justify-content: center;
   flex-grow: 1;
@@ -262,4 +256,9 @@ a.snapshot-list__item__json {
 .delta-row__content {
   transition: opacity .2s ease-in-out;
   line-height: 1.4;
+}
+
+.snapshot-list__item__information {
+  display: flex;
+  justify-content: flex-end;
 }

--- a/public/sass/components/snapshot-list.scss
+++ b/public/sass/components/snapshot-list.scss
@@ -106,19 +106,6 @@
     border-left: 1px solid $color-400-grey;
 }
 
-.snapshot-list__item__buttons {
-  display: flex;
-  height: 4.5em;
-  font-weight: 500;
-  z-index: 2;
-  [variant=quaternary] & {
-    color: white;
-  }
-  &:hover {
-    cursor: pointer;
-  }
-}
-
 .snapshot-list__item__settings__legally-sensitive {
     padding: 0;
     text-align: center;
@@ -199,47 +186,6 @@
 //no matter what :'(
 div.index-list__item__index {
   margin-bottom: 0;
-}
-
-// RESTORE BUTTON
-a.snapshot-list__item__restore {
-  display: flex;
-  height: 4.5em;
-  align-items: center;
-  justify-content: center;
-  flex-grow: 1;
-  background: $box-tertiary-bg;
-  transition: opacity .1s ease-in-out, background-color .2s ease-in-out;
-  z-index: 2;
-  border-left: 1px solid $color-400-grey;
-  &.active, &:hover {
-    background: darken($color-500-grey, 8%);
-  }
-}
-
-.snapshot-list__item__restore__icon {
-  margin-right: 5px;
-}
-
-//JSON BUTTON
-a.snapshot-list__item__json {
-  height: 4.5em;
-  align-items: center;
-  justify-content: center;
-  flex-grow: 1;
-  background: $box-tertiary-bg;
-  transition: opacity .1s ease-in-out;
-  z-index: 2;
-  border-left: 1px solid $color-400-grey;
-}
-
-//styling the element to get around specificity with components css files
-//these are always loaded last in dev so this is needed
-a.snapshot-list__item__json {
-  transition: background-color .2s ease-in-out;
-  &:hover, &.active {
-    background: darken($color-500-grey, 8%);
-  }
 }
 
 .delta-row {

--- a/public/sass/index.scss
+++ b/public/sass/index.scss
@@ -1,4 +1,5 @@
 @import "mixins/center-children";
+@import "mixins/borders";
 
 @import "components/snapshot-list.scss";
 @import "components/sidebar.scss";

--- a/public/sass/mixins/borders.scss
+++ b/public/sass/mixins/borders.scss
@@ -1,0 +1,3 @@
+@mixin thin-bottom-border {
+    border-bottom: 1px solid rgba(162, 160, 160, 0.49);
+}


### PR DESCRIPTION
There is now wider access to composer restorer but the limitations on the number of people who can restore has remained the same. The restore button should not be available to people who cannot restore content. Buttons were also moved from snapshot list to main section to simplify the layout of the snapshot list.

Moved JSON button and restore button:
![restorer - permission to restore](https://cloud.githubusercontent.com/assets/6666113/15211807/56aeb54c-1835-11e6-8086-076cacb9f29a.jpg)

Hide restore button when user cannot restore:
![restorer - no permission to restore](https://cloud.githubusercontent.com/assets/6666113/15211823/6eafc60e-1835-11e6-8d56-67e10248126d.jpg)

JSON button now allows the user to toggle between json and text:
![restorer - toggle text](https://cloud.githubusercontent.com/assets/6666113/15211842/872b16c0-1835-11e6-8433-d9e4348a804c.jpg)
