### PR TITLE
Sidebar: styling changes

### DIFF
--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -59,8 +59,8 @@
                 <div class="snapshot-list__item__content"
                      ng-class="{ 'active': model.get('activeState') && isDisplayingHTML }"
                      ng-click="ctrl.onItemClicked($index)">
-                    <h6 class="snapshot-list__item__content__relative-date">{{ model.getRelativeDate() }} ago</h6>
                     <h6 class="snapshot-list__item__content__actual-date">{{ model.getCreatedDate() }}</h6>
+                    <h6 class="snapshot-list__item__content__relative-date">{{ model.getRelativeDate() }} ago</h6>
                 </div>
                 <div class="snapshot-list__item__information">
                     <div class="snapshot-list__item__status"
@@ -107,7 +107,7 @@
             <li class="delta-row" ng-repeat-end ng-mouseover="isActive = true" ng-mouseout="isActive = false">
                 <gu-row variant="reverse">
                     <gu-icon class="delta-row__icon" variant="expand-disabled"></gu-icon>
-          <span class="delta-row__content" ng-class="{ 'visually-hidden': !isActive }">
+          <span class="delta-row__content">
             {{ model.getRelativeDate( models[$index + 1].get('createdDate') ) }}
           </span>
                 </gu-row>

--- a/public/sass/components/snapshot-list.scss
+++ b/public/sass/components/snapshot-list.scss
@@ -190,9 +190,7 @@ div.index-list__item__index {
 
 .delta-row {
   padding: 5px 0 2px 0;
-  &:hover {
-    cursor: pointer;
-  }
+  opacity: 0.3;
 }
 
 .delta-row__icon {

--- a/public/sass/components/text.scss
+++ b/public/sass/components/text.scss
@@ -50,14 +50,14 @@
 .index-list__item__index {
   margin-bottom: 5px;
   font-family: "Guardian Agate Sans";
-  font-weight: bold;
-  font-size: 16px;
+  font-weight: normal;
+  font-size: 13px;
 }
 
 .snapshot-list__item__content__actual-date {
   font-family: "Guardian Agate Sans";
-  font-weight: normal;
-  font-size: 13px;
+  font-weight: bold;
+  font-size: 16px;
 }
 
 a.snapshot-list__item__json, a.snapshot-list__item__restore {


### PR DESCRIPTION

<img width="332" alt="restorer-sideboard-styling-change" src="https://cloud.githubusercontent.com/assets/7312/15246681/b622046c-1906-11e6-8812-4011841937db.png">

This swaps the timestamp and the relative date around as the timestamp is the more valuable information.

It also makes the interval between snapshots always visible but less intrusive. This is a minor detail at the moment but when event driven snapshots start happening this information is more relevant and inconvenient to access with a hover over.